### PR TITLE
Update pasJaponais.pl

### DIFF
--- a/pasJaponais.pl
+++ b/pasJaponais.pl
@@ -8,13 +8,12 @@ testMoyenne([A, B, C], SortieAttendue) :-
 
 test("La moyenne de 1, 2 et 3 est 2", testMoyenne([1, 2, 3], 2)).
 test("La moyenne de 2, 2 et 2 est 2", testMoyenne([2, 2, 2], 2)).
+test("La moyenne de 2, 2 et 2 est 4", testMoyenne([2, 2, 2], 4)).
 
-testPass(Test, Entree, SortieAttendue) :-
-	call(Test, Entree, SortieAttendue).
+green(GreenTestName) :-
+    test(GreenTestName,  TestBody),
+    call(TestBody).
 
-testPass([Test, Entree, SortieAttendue]) :-
-    test(Test),
-	testPass(Test, Entree, SortieAttendue).
-    
-testsPass(Tests) :-
-    maplist(testPass, Tests).
+red(RedTestName) :-
+    test(RedTestName, TestBody),
+    not(call(TestBody)).


### PR DESCRIPTION
On ne peut pas definir "red" comme "not(green(RedTestName)", je pense qu'il y a l'explication [ici](https://www.cpp.edu/~jrfisher/www/prolog_tutorial/2_5.html), malheureusement le chapitre 8.8 auquel ile st fait reference plus plus de detail n'exist pas.